### PR TITLE
Fixing requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 syslogmp
 ed25519
-pprint
+pprintpp
 psutil
 jsonpickle
 configargparse


### PR DESCRIPTION
The package pprint could not be found, instead it should be pprintpp